### PR TITLE
Add syntax ref for filter option in gce_sd_config

### DIFF
--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -552,6 +552,8 @@ project: <string>
 zone: <string>
 
 # Filter can be used optionally to filter the instance list by other criteria
+# Syntax of this filter string is described here in the filter query parameter section:
+# https://cloud.google.com/compute/docs/reference/latest/instances/list
 [ filter: <string> ]
 
 # Refresh interval to re-read the instance list


### PR DESCRIPTION
The filter option in gce_sd_config has a particular syntax with some mandatory elements and it even accepts regular expressions. It would be useful to add a link to the syntax reference (I miss it myself when trying to use it and spent too much time looking for this information). 